### PR TITLE
Copy native crlibm source to _build directory

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -1,7 +1,7 @@
 module C = Configurator.V1
 
 (* This script is run in _build/<context>/src/ *)
-let crlibm_dir = "../../../src/crlibm"
+let crlibm_dir = "crlibm"
 
 let copy ?(src_dir=crlibm_dir) fn0 fn1 =
   let fh0 = open_in_bin (Filename.concat src_dir fn0) in

--- a/src/dune
+++ b/src/dune
@@ -33,5 +33,5 @@
 (rule
  (targets log-selected.c log2-selected.c log10-selected.c
           c_flags.sexp lib_flags.sexp)
- (deps    ../config/discover.exe)
+ (deps    ../config/discover.exe (source_tree crlibm))
  (action  (run %{deps})))


### PR DESCRIPTION
This removes the need to refer to the native crlibm source via a relative path which is brittle as the number of ".." components in the path varies depending on whether this packages is installed globally or vendored inside another package's source.